### PR TITLE
Replace simplejson with json

### DIFF
--- a/treeadmin/admin.py
+++ b/treeadmin/admin.py
@@ -3,13 +3,13 @@ from django.contrib import admin
 from django.contrib.admin.views import main
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, HttpResponseServerError
-from django.utils import simplejson
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, ugettext
 
 from mptt.exceptions import InvalidMove
 
 import logging
+import json as simplejson
 
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
For Django 1.5+ compat
    
(https://docs.djangoproject.com/en/1.8/releases/1.5/#system-version-of-simplejson-no-longer-used)