### PR TITLE
Work around attribute error

### DIFF
--- a/treeadmin/admin.py
+++ b/treeadmin/admin.py
@@ -146,7 +146,10 @@ class ChangeList(main.ChangeList):
         super(ChangeList, self).get_results(request)
 
         opts = self.model_admin.opts
-        label = opts.app_label + '.' + opts.get_change_permission()
+        try:
+            label = opts.app_label + '.' + opts.get_change_permission()
+        except AttributeError:
+            label = opts.app_label
         for item in self.result_list:
             if self.model_admin.enable_object_permissions:
                 item.feincms_editable = self.model_admin.has_change_permission(request, item)


### PR DESCRIPTION
Avoid this:

    [14/Sep/2015 15:32:46]"GET /static/bootstrap/fonts/glyphicons-halflings-regular.woff2 HTTP/1.1" 200 18028
    Internal Server Error: /admin/core/section/
    Traceback (most recent call last):
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/options.py", line 616, in wrapper
        return self.admin_site.admin_view(view)(*args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 110, in _wrapped_view
        response = view_func(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
        response = view_func(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/sites.py", line 233, in inner
        return view(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/src/django-treeadmin/treeadmin/admin.py", line 353, in changelist_view
        return super(TreeAdmin, self).changelist_view(request, extra_context, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 34, in _wrapper
        return bound_func(*args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 110, in _wrapped_view
        response = view_func(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 30, in bound_func
        return func.__get__(self, type(self))(*args2, **kwargs2)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/options.py", line 1548, in changelist_view
        self.list_max_show_all, self.list_editable, self)
      File "/Users/alexclark/Developer/natgeo/outofeden/src/django-treeadmin/treeadmin/admin.py", line 128, in __init__
        super(ChangeList, self).__init__(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/views/main.py", line 82, in __init__
        self.get_results(request)
      File "/Users/alexclark/Developer/natgeo/outofeden/src/django-treeadmin/treeadmin/admin.py", line 149, in get_results
        label = opts.app_label + '.' + opts.get_change_permission()
    AttributeError: 'Options' object has no attribute 'get_change_permission'
    django.request ERROR    Internal Server Error: /admin/core/section/
    Traceback (most recent call last):
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/options.py", line 616, in wrapper
        return self.admin_site.admin_view(view)(*args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 110, in _wrapped_view
        response = view_func(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
        response = view_func(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/sites.py", line 233, in inner
        return view(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/src/django-treeadmin/treeadmin/admin.py", line 353, in changelist_view
        return super(TreeAdmin, self).changelist_view(request, extra_context, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 34, in _wrapper
        return bound_func(*args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 110, in _wrapped_view
        response = view_func(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/utils/decorators.py", line 30, in bound_func
        return func.__get__(self, type(self))(*args2, **kwargs2)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/options.py", line 1548, in changelist_view
        self.list_max_show_all, self.list_editable, self)
      File "/Users/alexclark/Developer/natgeo/outofeden/src/django-treeadmin/treeadmin/admin.py", line 128, in __init__
        super(ChangeList, self).__init__(request, *args, **kwargs)
      File "/Users/alexclark/Developer/natgeo/outofeden/lib/python2.7/site-packages/django/contrib/admin/views/main.py", line 82, in __init__
        self.get_results(request)
      File "/Users/alexclark/Developer/natgeo/outofeden/src/django-treeadmin/treeadmin/admin.py", line 149, in get_results
        label = opts.app_label + '.' + opts.get_change_permission()
    AttributeError: 'Options' object has no attribute 'get_change_permission'